### PR TITLE
Add Validation to Post

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,6 +732,17 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
@@ -739,6 +750,12 @@ dependencies = [
  "unicode-bidi",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
 
 [[package]]
 name = "indexmap"
@@ -794,6 +811,7 @@ dependencies = [
  "serde",
  "serde_json",
  "uuid",
+ "validator",
 ]
 
 [[package]]
@@ -819,6 +837,12 @@ name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -877,6 +901,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
@@ -1474,7 +1504,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.3.0",
  "percent-encoding",
 ]
 
@@ -1486,6 +1516,48 @@ checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "validator"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32ad5bf234c7d3ad1042e5252b7eddb2c4669ee23f32c7dd0e9b7705f07ef591"
+dependencies = [
+ "idna 0.2.3",
+ "lazy_static",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc44ca3088bb3ba384d9aecf40c6a23a676ce23e09bdaca2073d99c207f864af"
+dependencies = [
+ "if_chain",
+ "lazy_static",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 1.0.109",
+ "validator_types",
+]
+
+[[package]]
+name = "validator_types"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "111abfe30072511849c5910134e8baf8dc05de4c0e5903d681cbd5c9c4d611e3"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ r2d2 = "0.8.10"
 serde = { version = "1.0.158", features = ["derive"] }
 serde_json = "1.0.94"
 uuid = { version = "1.3.0", features = ["serde", "v4"] }
+validator = { version = "0.16.0", features = ["derive"] }

--- a/src/api_error.rs
+++ b/src/api_error.rs
@@ -1,53 +1,72 @@
 use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, ResponseError};
 use diesel::result::Error as DieselError;
-use serde::Deserialize;
-use serde_json::json;
-use std::fmt;
+use serde::Serialize;
+use serde_json::to_string_pretty;
+use std::fmt::{Debug, Display, Formatter};
 
-#[derive(Debug, Deserialize)]
-pub struct ApiError {
-    pub code: u16,
-    pub message: String,
+#[derive(Debug, Serialize)]
+pub enum ApiError {
+    NotFound,
+    DatabaseError(String),
+    InternalServerError(String),
 }
 
-impl ApiError {
-    pub fn new(code: u16, message: String) -> ApiError {
-        ApiError { code, message }
+#[derive(Debug, Serialize)]
+pub struct ApiResponse<'a> {
+    pub code: u16,
+    pub message: &'a str,
+}
+
+impl ApiResponse<'_> {
+    pub fn new(code: u16, message: &str) -> String {
+        let api_resp = &ApiResponse { code, message };
+        to_string_pretty(api_resp).unwrap()
     }
 }
 
-impl fmt::Display for ApiError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(self.message.as_str())
+impl Display for ApiError {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        write!(f, "{}", to_string_pretty(self).unwrap())
     }
 }
 
 impl From<DieselError> for ApiError {
     fn from(error: DieselError) -> Self {
         match error {
-            DieselError::DatabaseError(_, err) => ApiError::new(409, err.message().to_string()),
-            DieselError::NotFound => ApiError::new(404, "Not Found".to_string()),
-            err => ApiError::new(500, format!("Diesel error: {}", err)),
+            DieselError::DatabaseError(_, err) => {
+                let message = err.message().to_string();
+                ApiError::DatabaseError(message)
+            }
+            DieselError::NotFound => ApiError::NotFound,
+            err => ApiError::InternalServerError(format!("Diesel Error: {}", err)),
         }
     }
 }
 
 impl ResponseError for ApiError {
+    fn status_code(&self) -> StatusCode {
+        match *self {
+            ApiError::NotFound => StatusCode::NOT_FOUND,
+            ApiError::DatabaseError(_) => StatusCode::CONFLICT,
+            ApiError::InternalServerError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
     fn error_response(&self) -> HttpResponse<actix_web::body::BoxBody> {
-        let status = match StatusCode::from_u16(self.code) {
-            Ok(status) => status,
-            Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        };
+        let status = self.status_code();
 
-        let message = match status.as_u16() < 500 {
-            true => self.message.clone(),
-            false => {
-                error!("{}", self.message);
-                "Internal server error".to_string()
+        match self {
+            ApiError::NotFound => {
+                let message = "Not Found";
+                HttpResponse::build(status).body(ApiResponse::new(status.as_u16(), message))
             }
-        };
-
-        HttpResponse::build(status).json(json!({ "message": message }))
+            ApiError::DatabaseError(message) => {
+                HttpResponse::build(status).body(ApiResponse::new(status.as_u16(), message))
+            }
+            ApiError::InternalServerError(message) => {
+                HttpResponse::build(status).body(ApiResponse::new(status.as_u16(), message))
+            }
+        }
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -24,5 +24,5 @@ pub fn init() {
 
 pub fn connection() -> Result<DbConnection, ApiError> {
     POOL.get()
-        .map_err(|e| ApiError::new(500, format!("Failed getting db connection: {}", e)))
+        .map_err(|e| ApiError::InternalServerError(format!("Failed getting db connection: {}", e)))
 }

--- a/src/posts/model.rs
+++ b/src/posts/model.rs
@@ -5,6 +5,7 @@ use chrono::prelude::*;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
+use validator::Validate;
 
 #[derive(Debug, PartialEq, Deserialize, Serialize, Queryable, Insertable)]
 #[diesel(table_name = posts)]
@@ -16,10 +17,12 @@ pub struct Post {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Deserialize, Serialize, AsChangeset)]
+#[derive(Debug, Deserialize, Serialize, Validate, AsChangeset)]
 #[diesel(table_name = posts)]
 pub struct PostParams {
+    #[validate(length(min = 1, max = 256))]
     pub title: String,
+    #[validate(length(min = 1, max = 65536))]
     pub body: String,
     pub updated_at: Option<NaiveDateTime>,
 }

--- a/src/posts/route.rs
+++ b/src/posts/route.rs
@@ -3,6 +3,7 @@ use crate::posts::*;
 use actix_web::{delete, get, patch, post, web, HttpRequest, HttpResponse, Result};
 use serde_json::to_string_pretty;
 use uuid::Uuid;
+use validator::Validate;
 
 #[get("/posts")]
 async fn find_all() -> Result<HttpResponse, ApiError> {
@@ -22,6 +23,7 @@ async fn find(req: HttpRequest) -> Result<HttpResponse, ApiError> {
 
 #[post("/posts")]
 async fn create(post: web::Json<PostParams>) -> Result<HttpResponse, ApiError> {
+    post.validate()?;
     let post = Post::create(post.into_inner())?;
     let post = to_string_pretty(&post).unwrap();
     Ok(HttpResponse::Created().body(post))
@@ -29,6 +31,7 @@ async fn create(post: web::Json<PostParams>) -> Result<HttpResponse, ApiError> {
 
 #[patch("/posts/{id}")]
 async fn update(req: HttpRequest, post: web::Json<PostParams>) -> Result<HttpResponse, ApiError> {
+    post.validate()?;
     let id: Uuid = req.match_info().query("id").parse().unwrap_or_default();
     let post = Post::update(id, post.into_inner())?;
     let post = to_string_pretty(&post).unwrap();

--- a/src/posts/test.rs
+++ b/src/posts/test.rs
@@ -122,7 +122,8 @@ mod routes {
         })
     });
 
-    static RESP_NOT_FOUND: Lazy<Value> = Lazy::new(|| json!({"message": "Not Found".to_string()}));
+    static RESP_NOT_FOUND: Lazy<Value> =
+        Lazy::new(|| json!({"code": 404, "message": "Not Found".to_string()}));
 
     fn create_post() -> Post {
         let post = PostParams {

--- a/src/posts/test.rs
+++ b/src/posts/test.rs
@@ -44,6 +44,43 @@ mod routes {
     #[actix_web::test]
     async fn create() {
         let app = init_service(App::new().configure(init_routes)).await;
+        // // No send POST data
+        // let resp = TestRequest::post()
+        //     .uri("/posts")
+        //     .set_json({})
+        //     .send_request(&app)
+        //     .await;
+        // assert!(resp.status().is_client_error());
+        // let resp: Value = read_body_json(resp).await;
+        // assert_eq!(
+        //     resp,
+        //     json!({ "errors": [
+        //         { "code": 422, "title": "title is required"},
+        //         { "code": 422, "body": "body is required"},
+        //     ]})
+        // );
+        // Empty POST data
+        let request_body = INVALID_JSON.to_owned();
+        let resp = TestRequest::post()
+            .uri("/posts")
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let required = RESP_REQUIRED.to_owned();
+        assert_eq!(resp, required);
+        // Too long POST data
+        let request_body = INVALID_JSON_2.to_owned();
+        let resp = TestRequest::post()
+            .uri("/posts")
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let too_long = RESP_TOO_LONG.to_owned();
+        assert_eq!(resp, too_long);
         // success test
         let request_body = VALID_JSON.to_owned();
         let resp = TestRequest::post()
@@ -62,7 +99,7 @@ mod routes {
     async fn update() {
         let app = init_service(App::new().configure(init_routes)).await;
         let post = create_post();
-        // success test
+        // Post not found
         let request_body = VALID_JSON.to_owned();
         let resp = TestRequest::patch()
             .uri("/posts/asdf")
@@ -73,7 +110,45 @@ mod routes {
         let resp: Value = read_body_json(resp).await;
         let resp_not_found = RESP_NOT_FOUND.to_owned();
         assert_eq!(resp, resp_not_found);
+        // // No send POST data
+        // let resp = TestRequest::patch()
+        //     .uri(&format!("/posts/{}", post.id))
+        //     .set_json({})
+        //     .send_request(&app)
+        //     .await;
+        // assert!(resp.status().is_client_error());
+        // let resp: Value = read_body_json(resp).await;
+        // assert_eq!(
+        //     resp,
+        //     json!({ "errors": [
+        //         { "code": 422, "title": "title is required"},
+        //         { "code": 422, "body": "body is required"},
+        //     ]})
+        // );
+        // Empty POST data
+        let request_body = INVALID_JSON.to_owned();
+        let resp = TestRequest::patch()
+            .uri(&format!("/posts/{}", post.id))
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let required = RESP_REQUIRED.to_owned();
+        assert_eq!(resp, required);
+        // Too long POST data
+        let request_body = INVALID_JSON_2.to_owned();
+        let resp = TestRequest::patch()
+            .uri(&format!("/posts/{}", post.id))
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let too_long = RESP_TOO_LONG.to_owned();
+        assert_eq!(resp, too_long);
         // success test
+        let request_body = VALID_JSON.to_owned();
         let resp = TestRequest::patch()
             .uri(&format!("/posts/{}", post.id))
             .set_json(&request_body)
@@ -122,8 +197,36 @@ mod routes {
         })
     });
 
+    static INVALID_JSON: Lazy<Value> = Lazy::new(|| {
+        json!({
+            "title": "",
+            "body":  "",
+        })
+    });
+
+    static INVALID_JSON_2: Lazy<Value> = Lazy::new(|| {
+        json!({
+            "title": "a".repeat(257),
+            "body":  "a".repeat(65537),
+        })
+    });
+
     static RESP_NOT_FOUND: Lazy<Value> =
         Lazy::new(|| json!({"code": 404, "message": "Not Found".to_string()}));
+
+    static RESP_REQUIRED: Lazy<Value> = Lazy::new(|| {
+        json!({ "errors": [
+            { "code": 422, "message": "body is required"},
+            { "code": 422, "message": "title is required"},
+        ]})
+    });
+
+    static RESP_TOO_LONG: Lazy<Value> = Lazy::new(|| {
+        json!({ "errors": [
+            { "code": 422, "message": "body is too long"},
+            { "code": 422, "message": "title is too long"},
+        ]})
+    });
 
     fn create_post() -> Post {
         let post = PostParams {


### PR DESCRIPTION
# 概要

Postモデルにバリデーションを追加

## 変更内容

ApiErrorを少し変更しました。しかし呼び出し側での変更は特にありません。

## 影響範囲

他の機能に影響は与えません

## 動作要件

[validator](https://github.com/Keats/validator)クレートを追加。

### 補足

アプリを立ち上げて以下のコマンドを実行してみてください。エラーレスポンスが返ってくるはずです。

```bash
curl http://0.0.0.0:8080/posts -X POST -H "Content-Type: application/json" -d '{"title": "", "body": ""}'
curl http://0.0.0.0:8080/posts/:insert_uuid -X PATCH -H "Content-Type: application/json" -d '{"title": "", "body": ""}'
```