### PR TITLE
Add comment function for posts

### DIFF
--- a/migrations/2023-04-01-160457_create_comments/down.sql
+++ b/migrations/2023-04-01-160457_create_comments/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "comments";

--- a/migrations/2023-04-01-160457_create_comments/up.sql
+++ b/migrations/2023-04-01-160457_create_comments/up.sql
@@ -1,0 +1,9 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+CREATE TABLE "comments" (
+	id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+	body TEXT NOT NULL,
+	post_id UUID REFERENCES posts(id) NOT NULL,
+	created_at TIMESTAMP NOT NULL DEFAULT current_timestamp,
+	updated_at TIMESTAMP NOT NULL DEFAULT current_timestamp
+);

--- a/src/comments/mod.rs
+++ b/src/comments/mod.rs
@@ -1,0 +1,3 @@
+mod route;
+
+pub use route::init_routes;

--- a/src/comments/mod.rs
+++ b/src/comments/mod.rs
@@ -1,3 +1,6 @@
+mod model;
 mod route;
+mod test;
 
+pub use model::*;
 pub use route::init_routes;

--- a/src/comments/model.rs
+++ b/src/comments/model.rs
@@ -1,0 +1,64 @@
+use crate::api_error::ApiError;
+use crate::db;
+use crate::posts::Post;
+use crate::schema::comments;
+use chrono::prelude::*;
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use validator::{Validate, ValidationError};
+
+#[derive(Serialize, Deserialize, Queryable, Selectable, Identifiable, Associations)]
+#[diesel(belongs_to(Post))]
+#[diesel(table_name = comments)]
+pub struct Comment {
+    pub id: Uuid,
+    pub body: String,
+    pub post_id: Uuid,
+    pub created_at: NaiveDateTime,
+    pub updated_at: NaiveDateTime,
+}
+
+#[derive(Deserialize, Validate, AsChangeset)]
+#[diesel(table_name = comments)]
+pub struct CommentParams {
+    #[validate(custom = "validate_body")]
+    pub body: String,
+    pub updated_at: Option<NaiveDateTime>,
+}
+
+impl Comment {
+    pub async fn find_all(post_id: Uuid) -> Result<Vec<Self>, ApiError> {
+        let conn = &mut db::connection()?;
+        let post = Post::find(post_id)?;
+        let comments = Comment::belonging_to(&post)
+            .select(Comment::as_select())
+            .load(conn)?;
+        Ok(comments)
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct CommentFindAll {
+    pub total_count: usize,
+    pub comments: Vec<Comment>,
+}
+
+impl CommentFindAll {
+    pub fn new(total_count: usize, comments: Vec<Comment>) -> Self {
+        CommentFindAll {
+            total_count,
+            comments,
+        }
+    }
+}
+
+fn validate_body(body: &str) -> Result<(), ValidationError> {
+    if body.is_empty() {
+        return Err(ValidationError::new("body is required"));
+    } else if body.len() > 65536 {
+        return Err(ValidationError::new("body is too long"));
+    }
+
+    Ok(())
+}

--- a/src/comments/route.rs
+++ b/src/comments/route.rs
@@ -4,6 +4,7 @@ use actix_web::{delete, get, post, web, HttpRequest, HttpResponse, Result};
 use serde_json::json;
 use serde_json::to_string_pretty;
 use uuid::Uuid;
+use validator::Validate;
 
 use chrono::prelude::*;
 
@@ -16,17 +17,16 @@ async fn find_all(req: HttpRequest) -> Result<HttpResponse, ApiError> {
     Ok(HttpResponse::Ok().body(comments))
 }
 
-#[post("/posts/{post_id}/comments/{comment_id}")]
-async fn create(req: HttpRequest) -> Result<HttpResponse, ApiError> {
+#[post("/posts/{post_id}/comments")]
+async fn create(
+    req: HttpRequest,
+    comment: web::Json<CommentParams>,
+) -> Result<HttpResponse, ApiError> {
+    comment.validate()?;
     let post_id: Uuid = find_query_id(&req, "post_id");
-    let comment_id: Uuid = find_query_id(&req, "comment_id");
-    Ok(HttpResponse::Ok().json(json!({
-        "id": comment_id,
-        "body": "Create Comment",
-        "post_id": post_id,
-        "created_at": Some(Utc::now().naive_utc()),
-        "updated_at": Some(Utc::now().naive_utc())
-    })))
+    let comment = Comment::create(post_id, comment.into_inner()).await?;
+    let comment = to_string_pretty(&comment).unwrap();
+    Ok(HttpResponse::Ok().body(comment))
 }
 
 #[delete("/posts/{post_id}/comments/{comment_id}")]

--- a/src/comments/route.rs
+++ b/src/comments/route.rs
@@ -1,17 +1,14 @@
 use crate::api_error::ApiError;
 use crate::comments::*;
 use actix_web::{delete, get, post, web, HttpRequest, HttpResponse, Result};
-use serde_json::json;
 use serde_json::to_string_pretty;
 use uuid::Uuid;
 use validator::Validate;
 
-use chrono::prelude::*;
-
 #[get("/posts/{post_id}/comments")]
 async fn find_all(req: HttpRequest) -> Result<HttpResponse, ApiError> {
     let post_id: Uuid = find_query_id(&req, "post_id");
-    let comments = Comment::find_all(post_id).await?;
+    let comments = Comment::find_all(post_id)?;
     let comments = CommentFindAll::new(comments.len(), comments);
     let comments = to_string_pretty(&comments).unwrap();
     Ok(HttpResponse::Ok().body(comments))
@@ -24,7 +21,7 @@ async fn create(
 ) -> Result<HttpResponse, ApiError> {
     comment.validate()?;
     let post_id: Uuid = find_query_id(&req, "post_id");
-    let comment = Comment::create(post_id, comment.into_inner()).await?;
+    let comment = Comment::create(post_id, comment.into_inner())?;
     let comment = to_string_pretty(&comment).unwrap();
     Ok(HttpResponse::Ok().body(comment))
 }
@@ -33,13 +30,9 @@ async fn create(
 async fn delete(req: HttpRequest) -> Result<HttpResponse, ApiError> {
     let post_id: Uuid = find_query_id(&req, "post_id");
     let comment_id: Uuid = find_query_id(&req, "comment_id");
-    Ok(HttpResponse::Ok().json(json!({
-        "id": comment_id,
-        "body": "Delete Comment",
-        "post_id": post_id,
-        "created_at": Some(Utc::now().naive_utc()),
-        "updated_at": Some(Utc::now().naive_utc())
-    })))
+    let comment = Comment::delete(post_id, comment_id)?;
+    let comment = to_string_pretty(&comment).unwrap();
+    Ok(HttpResponse::Ok().body(comment))
 }
 
 fn find_query_id(req: &HttpRequest, params: &str) -> Uuid {

--- a/src/comments/route.rs
+++ b/src/comments/route.rs
@@ -1,0 +1,59 @@
+use crate::api_error::ApiError;
+use actix_web::{delete, get, post, web, HttpRequest, HttpResponse, Result};
+use serde_json::json;
+use uuid::Uuid;
+
+use chrono::prelude::*;
+
+#[get("/posts/{post_id}/comments")]
+async fn find_all(req: HttpRequest) -> Result<HttpResponse, ApiError> {
+    let post_id: Uuid = find_query_id(&req, "post_id");
+    Ok(HttpResponse::Ok().json(json!({
+        "total_count": 1,
+        "comments": [
+        {
+            "id": Uuid::new_v4(),
+            "body": "Find All Comments",
+            "post_id": post_id,
+            "created_at": Some(Utc::now().naive_utc()),
+            "updated_at": Some(Utc::now().naive_utc()),
+        }
+    ]
+    })))
+}
+
+#[post("/posts/{post_id}/comments/{comment_id}")]
+async fn create(req: HttpRequest) -> Result<HttpResponse, ApiError> {
+    let post_id: Uuid = find_query_id(&req, "post_id");
+    let comment_id: Uuid = find_query_id(&req, "comment_id");
+    Ok(HttpResponse::Ok().json(json!({
+        "id": comment_id,
+        "body": "Create Comment",
+        "post_id": post_id,
+        "created_at": Some(Utc::now().naive_utc()),
+        "updated_at": Some(Utc::now().naive_utc())
+    })))
+}
+
+#[delete("/posts/{post_id}/comments/{comment_id}")]
+async fn delete(req: HttpRequest) -> Result<HttpResponse, ApiError> {
+    let post_id: Uuid = find_query_id(&req, "post_id");
+    let comment_id: Uuid = find_query_id(&req, "comment_id");
+    Ok(HttpResponse::Ok().json(json!({
+        "id": comment_id,
+        "body": "Delete Comment",
+        "post_id": post_id,
+        "created_at": Some(Utc::now().naive_utc()),
+        "updated_at": Some(Utc::now().naive_utc())
+    })))
+}
+
+fn find_query_id(req: &HttpRequest, params: &str) -> Uuid {
+    req.match_info().query(params).parse().unwrap_or_default()
+}
+
+pub fn init_routes(cfg: &mut web::ServiceConfig) {
+    cfg.service(find_all);
+    cfg.service(create);
+    cfg.service(delete);
+}

--- a/src/comments/route.rs
+++ b/src/comments/route.rs
@@ -1,6 +1,8 @@
 use crate::api_error::ApiError;
+use crate::comments::*;
 use actix_web::{delete, get, post, web, HttpRequest, HttpResponse, Result};
 use serde_json::json;
+use serde_json::to_string_pretty;
 use uuid::Uuid;
 
 use chrono::prelude::*;
@@ -8,18 +10,10 @@ use chrono::prelude::*;
 #[get("/posts/{post_id}/comments")]
 async fn find_all(req: HttpRequest) -> Result<HttpResponse, ApiError> {
     let post_id: Uuid = find_query_id(&req, "post_id");
-    Ok(HttpResponse::Ok().json(json!({
-        "total_count": 1,
-        "comments": [
-        {
-            "id": Uuid::new_v4(),
-            "body": "Find All Comments",
-            "post_id": post_id,
-            "created_at": Some(Utc::now().naive_utc()),
-            "updated_at": Some(Utc::now().naive_utc()),
-        }
-    ]
-    })))
+    let comments = Comment::find_all(post_id).await?;
+    let comments = CommentFindAll::new(comments.len(), comments);
+    let comments = to_string_pretty(&comments).unwrap();
+    Ok(HttpResponse::Ok().body(comments))
 }
 
 #[post("/posts/{post_id}/comments/{comment_id}")]

--- a/src/comments/test.rs
+++ b/src/comments/test.rs
@@ -1,9 +1,12 @@
 #[cfg(test)]
 mod routes {
     use crate::comments::*;
+    use crate::config;
     use crate::posts::{Post, PostParams};
-    use actix_web::test::{init_service, TestRequest};
+    use actix_web::test::{init_service, read_body_json, TestRequest};
     use actix_web::App;
+    use once_cell::sync::Lazy;
+    use serde_json::{json, Value};
 
     #[actix_web::test]
     async fn find_all() {
@@ -14,6 +17,9 @@ mod routes {
             .send_request(&app)
             .await;
         assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let json_resp = RESP_NOT_FOUND.to_owned();
+        assert_eq!(resp, json_resp);
         // success test
         let post = create_post();
         let resp = TestRequest::get()
@@ -23,6 +29,88 @@ mod routes {
         assert!(resp.status().is_success());
         delete_post(post);
     }
+
+    #[actix_web::test]
+    async fn create() {
+        let app = init_service(App::new().configure(config::init).configure(init_routes)).await;
+        // Post not found
+        let resp = TestRequest::get()
+            .uri("/posts/asdf/comments")
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let json_resp = RESP_NOT_FOUND.to_owned();
+        assert_eq!(resp, json_resp);
+        // No send post data
+        let post = create_post();
+        let resp = TestRequest::post()
+            .uri(&format!("/posts/{}/comments", post.id))
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let json_resp = RESP_INCORRECT.to_owned();
+        assert_eq!(resp, json_resp);
+        // Empty POST data
+        let request_body = INVALID_JSON.to_owned();
+        let resp = TestRequest::post()
+            .uri(&format!("/posts/{}/comments", post.id))
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let json_resp = RESP_REQUIRED.to_owned();
+        assert_eq!(resp, json_resp);
+        // Too long POST data
+        let request_body = INVALID_JSON_2.to_owned();
+        let resp = TestRequest::post()
+            .uri(&format!("/posts/{}/comments", post.id))
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        let resp: Value = read_body_json(resp).await;
+        let json_resp = RESP_TOO_LONG.to_owned();
+        assert_eq!(resp, json_resp);
+        // Success test
+        let request_body = VALID_JSON.to_owned();
+        let resp = TestRequest::post()
+            .uri(&format!("/posts/{}/comments", post.id))
+            .set_json(&request_body)
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_success());
+        let resp: Comment = read_body_json(resp).await;
+        assert_eq!(resp.body, "Test Comment");
+        // initialize post
+        delete_post(post)
+    }
+
+    static VALID_JSON: Lazy<Value> = Lazy::new(|| json!({ "body": "Test Comment", }));
+
+    static INVALID_JSON: Lazy<Value> = Lazy::new(|| json!({ "body": "", }));
+
+    static INVALID_JSON_2: Lazy<Value> = Lazy::new(|| json!({ "body": "a".repeat(65537) }));
+
+    static RESP_NOT_FOUND: Lazy<Value> =
+        Lazy::new(|| json!({"code": 404, "message": "Not Found".to_string()}));
+
+    static RESP_REQUIRED: Lazy<Value> = Lazy::new(|| {
+        json!({ "errors": [
+            { "code": 422, "message": "body is required"},
+        ]})
+    });
+
+    static RESP_TOO_LONG: Lazy<Value> = Lazy::new(|| {
+        json!({ "errors": [
+            { "code": 422, "message": "body is too long"},
+        ]})
+    });
+
+    static RESP_INCORRECT: Lazy<Value> =
+        Lazy::new(|| json!({ "code": 400, "message": "Post Request is Incorrect" }));
 
     fn create_post() -> Post {
         let post = PostParams {
@@ -36,4 +124,18 @@ mod routes {
     fn delete_post(post: Post) {
         Post::delete(post.id).expect("Failed delete_post(id)");
     }
+
+    // async fn create_comment(post: Post) -> Comment {
+    //     let comment = CommentParams {
+    //         body: "This is a create_comment()".to_string(),
+    //         updated_at: None,
+    //     };
+    //     Comment::create(post.id, comment)
+    //         .await
+    //         .expect("Failed create_comment()")
+    // }
+
+    // async fn delete_comment(comment: Comment) {
+    //     Comment::delete(comment.id).expect("Failed delete_comment(comment)")
+    // }
 }

--- a/src/comments/test.rs
+++ b/src/comments/test.rs
@@ -1,0 +1,39 @@
+#[cfg(test)]
+mod routes {
+    use crate::comments::*;
+    use crate::posts::{Post, PostParams};
+    use actix_web::test::{init_service, TestRequest};
+    use actix_web::App;
+
+    #[actix_web::test]
+    async fn find_all() {
+        let app = init_service(App::new().configure(init_routes)).await;
+        // Post not found
+        let resp = TestRequest::get()
+            .uri("/posts/asdf/comments")
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_client_error());
+        // success test
+        let post = create_post();
+        let resp = TestRequest::get()
+            .uri(&format!("/posts/{}/comments", post.id))
+            .send_request(&app)
+            .await;
+        assert!(resp.status().is_success());
+        delete_post(post);
+    }
+
+    fn create_post() -> Post {
+        let post = PostParams {
+            title: "create_post()".to_string(),
+            body: "This is a create_post()".to_string(),
+            updated_at: None,
+        };
+        Post::create(post).expect("Failed create_post()")
+    }
+
+    fn delete_post(post: Post) {
+        Post::delete(post.id).expect("Failed delete_post(id)");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use actix_web::{App, HttpServer};
 use std::env;
 
 mod api_error;
+mod comments;
 mod config;
 mod db;
 mod posts;
@@ -23,6 +24,7 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::default())
             .configure(config::init)
             .configure(posts::init_routes)
+            .configure(comments::init_routes)
     };
 
     info!("Starting Server: http://{host}:{port}");

--- a/src/posts/model.rs
+++ b/src/posts/model.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 use validator::{Validate, ValidationError};
 
-#[derive(Debug, PartialEq, Deserialize, Serialize, Queryable, Insertable)]
+#[derive(Debug, PartialEq, Deserialize, Serialize, Queryable, Identifiable, Insertable)]
 #[diesel(table_name = posts)]
 pub struct Post {
     pub id: Uuid,
@@ -17,7 +17,7 @@ pub struct Post {
     pub updated_at: NaiveDateTime,
 }
 
-#[derive(Debug, Deserialize, Serialize, Validate, AsChangeset)]
+#[derive(Debug, Deserialize, Validate, AsChangeset)]
 #[diesel(table_name = posts)]
 pub struct PostParams {
     #[validate(custom = "validate_title")]
@@ -102,7 +102,7 @@ impl PostFindAll {
     }
 }
 
-fn validate_title(title: &str) ->Result<(), ValidationError> {
+fn validate_title(title: &str) -> Result<(), ValidationError> {
     if title.is_empty() {
         return Err(ValidationError::new("title is required"));
     } else if title.len() > 256 {
@@ -112,7 +112,7 @@ fn validate_title(title: &str) ->Result<(), ValidationError> {
     Ok(())
 }
 
-fn validate_body(body: &str) ->Result<(), ValidationError> {
+fn validate_body(body: &str) -> Result<(), ValidationError> {
     if body.is_empty() {
         return Err(ValidationError::new("body is required"));
     } else if body.len() > 65536 {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,16 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    comments (id) {
+        id -> Uuid,
+        body -> Text,
+        post_id -> Uuid,
+        created_at -> Timestamp,
+        updated_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     posts (id) {
         id -> Uuid,
         title -> Varchar,
@@ -9,3 +19,10 @@ diesel::table! {
         updated_at -> Timestamp,
     }
 }
+
+diesel::joinable!(comments -> posts (post_id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    comments,
+    posts,
+);


### PR DESCRIPTION
概要

記事のコメント機能を追加

変更内容

`/comments`ディレクトリを追加。
`/posts/model.rs`の`delete`関数に、コメントを削除するコードを追加。

影響範囲

以下のURLにアクセス可能になる

- `GET /posts/{post_id}/comments`
- `POST /posts/{post_id}/comments`
- `DELETE /posts/{post_id}/comments/{comment_id}`

動作要件

特になし

補足

特になし